### PR TITLE
lib: Expose API to set/get the pipeline

### DIFF
--- a/tests/features/basic.feature
+++ b/tests/features/basic.feature
@@ -2,8 +2,8 @@ Feature: Basic pipeline manipulation
 
   Background:
     Given The validate configuration 'validateflow, expectations-dir=tmp/, pad=sink:sink, ignored-event-types={ tag }'
-    Given Validate is activated
     Given Pipeline is 'videotestsrc name=src ! fakevideosink enable-last-sample=true name=sink'
+    Given Validate is activated
 
   Scenario: video source pattern
     When I play the pipeline


### PR DESCRIPTION
The pipeline is now stored internally as parse-launch'd element, so that the
actual pipeline is not wrapped in another bin, that simplifies things in cases
where a test needs to send a downstream event, for instance.

`check_significant_color_on_element()` and `get_last_frame_on_element()` are
also exposed so that third-party steps can reuse those functions, in cases where
they use playbin and thus have their video sink wrapped deep in the pipeline.