### PR TITLE
lib: Make GstValidate support optional

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,30 +12,14 @@ jobs:
   release:
     name: Deploy Documentation
     runs-on: ubuntu-latest
-    env:
-      PKG_CONFIG_PATH: "/usr/local/lib/x86_64-linux-gnu/pkgconfig"
-      GST_PLUGIN_SYSTEM_PATH: "/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0"
-      GST_PLUGIN_SCANNER: "/usr/local/libexec/gstreamer-1.0/gst-plugin-scanner"
-      LD_LIBRARY_PATH: "/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Install Build Dependencies
+      - name: Install Dependencies
         run: |
          sudo apt update
-         sudo apt install libglib2.0-dev ninja-build
-         sudo python -m pip install --upgrade pip setuptools wheel
-         sudo pip install meson==0.60.3
-
-      - name: Build GStreamer 1.21
-        run: |
-          git clone --depth 1 https://gitlab.freedesktop.org/gstreamer/gstreamer.git --branch main
-          pushd gstreamer
-          meson build -Dprefix=/usr/local -Ddoc=disabled -Dtests=disabled -Dintrospection=disabled -Dges=disabled -Dqt5=disabled -Dgst-examples=disabled -Dexamples=disabled -Dgtk_doc=disabled -Dlibav=disabled -Dlibnice=disabled -Dpython=disabled -Dugly=disabled -Dgood=disabled -Ddevtools=enabled -Dvaapi=disabled
-          ninja -C build
-          sudo ninja -C build install
-          popd
+         sudo apt install libgstreamer1.0-dev libgstreamer-plugins-{bad,base}1.0-dev 
 
       - name: Build Documentation
         run: cargo doc --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,6 @@ jobs:
     - name: rustfmt
       run: cargo fmt -- --check
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --features validate
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --features validate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ readme = "README.md"
 [dependencies]
 cucumber = "0.12"
 async-trait = "0.1.52"
-gst = { git = "https://gitlab.freedesktop.org/philn/gstreamer-rs.git", branch = "validate-crate", package = "gstreamer", features = ["v1_20", "ser_de"] }
-gstvideo = { git = "https://gitlab.freedesktop.org/philn/gstreamer-rs.git", branch = "validate-crate", package = "gstreamer-video" }
-gstvalidate = { git = "https://gitlab.freedesktop.org/philn/gstreamer-rs.git", branch = "validate-crate", package = "gstreamer-validate" }
+# TODO: Switch to upstream repo after gstreamer-validate made it upstream...
+gstreamer = { git = "https://gitlab.freedesktop.org/philn/gstreamer-rs.git", branch = "validate-crate", package = "gstreamer" }
+gstreamer-video = { git = "https://gitlab.freedesktop.org/philn/gstreamer-rs.git", branch = "validate-crate", package = "gstreamer-video" }
+gstreamer-validate = { git = "https://gitlab.freedesktop.org/philn/gstreamer-rs.git", branch = "validate-crate", package = "gstreamer-validate", features = ["v1_22"], optional = true }
 anyhow = "1"
 tempfile = "3"
 once_cell = "1.0"
@@ -29,3 +30,6 @@ glib = "0.15"
 [[test]]
 name = "basic"
 harness = false
+
+[features]
+validate = ["gstreamer-validate"]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -2,7 +2,7 @@ use glib;
 use gstreamer_cucumber::World;
 
 async fn async_main() -> Result<(), anyhow::Error> {
-    gst::init()?;
+    gstreamer::init()?;
     World::run("tests/features/basic.feature", None).await;
     Ok(())
 }


### PR DESCRIPTION
Also don't use 1.20 API, so that this crate can be used on GStreamer 1.18
runtimes.