### PR TITLE
lib: Send an EOS when stopping the pipeline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,4 +524,5 @@ pub mod prelude {
     #[doc(hidden)]
     pub use gst::prelude::*;
     pub use gstreamer as gst;
+    pub use gstreamer_video as gstvideo;
 }


### PR DESCRIPTION
Some pipelines (for instance involving mp4mux and a filesink) require proper EOS
dispatching from the app.